### PR TITLE
Work for files containing line delimited features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geojson-stream-merge
 
-Creates a single valid `FeatureCollection` from a file of line delimited feature collections.
+Creates a single valid `FeatureCollection` from a file of line delimited features or feature collections.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ function geojsonStreamMerge(inputFile, outputFile, callback) {
     }
     if (!outputFile) {
         outputFile = inputFile.split('.')[0] + '-merged.geojson';
-
+    }
+    //if output file exists, overwrite file instead of appending to it.
+    if (fs.existsSync(outputFile)) {
+        fs.unlinkSync(outputFile);
     }
     var inputStream = fs.createReadStream(inputFile, {encoding: 'utf8'}).pipe(split());
 

--- a/index.js
+++ b/index.js
@@ -28,17 +28,16 @@ function geojsonStreamMerge(inputFile, outputFile, callback) {
         process.stderr.cursorTo(0);
         process.stderr.write('Processing line: ' + String(line));
         if (chunk) {
-            var featureCollectionExists = JSON.parse(chunk).features;
-            var features = featureCollectionExists ? JSON.parse(chunk).features : JSON.parse(chunk);
-            if (featureCollectionExists) {
-                features.forEach(function (feature) {
+            var json = JSON.parse(chunk);
+            if (json.features) {
+                json.features.forEach(function (feature) {
                     fs.appendFileSync(outputFile, comma + JSON.stringify(feature), {encoding: 'utf8'});
                     if (!comma) {
                         comma = ',';
                     }
                 });
             } else {
-                fs.appendFileSync(outputFile, comma + JSON.stringify(features), {encoding: 'utf8'});
+                fs.appendFileSync(outputFile, comma + JSON.stringify(json), {encoding: 'utf8'});
                 if (!comma) {
                     comma = ',';
                 }

--- a/index.js
+++ b/index.js
@@ -28,13 +28,21 @@ function geojsonStreamMerge(inputFile, outputFile, callback) {
         process.stderr.cursorTo(0);
         process.stderr.write('Processing line: ' + String(line));
         if (chunk) {
-            var features = JSON.parse(chunk).features;
-            features.forEach(function (feature) {
-                fs.appendFileSync(outputFile, comma + JSON.stringify(feature), {encoding: 'utf8'});
+            var featureCollectionExists = JSON.parse(chunk).features;
+            var features = featureCollectionExists ? JSON.parse(chunk).features : JSON.parse(chunk);
+            if (featureCollectionExists) {
+                features.forEach(function (feature) {
+                    fs.appendFileSync(outputFile, comma + JSON.stringify(feature), {encoding: 'utf8'});
+                    if (!comma) {
+                        comma = ',';
+                    }
+                });
+            } else {
+                fs.appendFileSync(outputFile, comma + JSON.stringify(features), {encoding: 'utf8'});
                 if (!comma) {
                     comma = ',';
                 }
-            });
+            }
         }
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,16 @@ tape('check if the output is as per expected', function (assert) {
         assert.ifError(err);
         assert.end();
     });
+});
 
+tape('check output when the input file contains line-delimited features instead of line-delimited feature collections', function (assert) {
+    geojsonStreamMerge(join(__dirname, '/testInputFeatures.json'), join(__dirname, '/output.geojson'), function (err) {
+        var output = fs.readFileSync(join(__dirname, '/output.geojson'), 'utf8');
+        var testOutput = fs.readFileSync(join(__dirname, '/testOutput.geojson'), 'utf8');
+        assert.equals(output, testOutput, 'ok, valid output');
+        assert.ifError(err);
+        assert.end();
+    });
 });
 
 tape('is geojson valid', function (assert) {

--- a/test/testInputFeatures.json
+++ b/test/testInputFeatures.json
@@ -1,0 +1,6 @@
+{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[[22.8515625,-1.7575368113083125],[43.9453125,-1.7575368113083125]]}}
+{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[71.71875,22.917922936146045]}}
+{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[[22.8515625,-1.7575368113083125],[43.9453125,-1.7575368113083125]]}}
+{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[71.71875,22.917922936146045]}}
+{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[[22.8515625,-1.7575368113083125],[43.9453125,-1.7575368113083125]]}}
+{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[71.71875,22.917922936146045]}}


### PR DESCRIPTION
As opposed to working only for files containing line delimited feature collections, make `geojson-stream-merge` work for files that contain line delimited features too.

@geohacker let me know what you think, will wait for a review.

cc/ @amishas157 
