### PR TITLE
Overwrite o/p file if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ function geojsonStreamMerge(inputFile, outputFile, callback) {
     }
     if (!outputFile) {
         outputFile = inputFile.split('.')[0] + '-merged.geojson';
-
+    }
+    //if output file exists, overwrite file instead of appending to it.
+    if (fs.existsSync(outputFile)) {
+        fs.unlinkSync(outputFile);
     }
     var inputStream = fs.createReadStream(inputFile, {encoding: 'utf8'}).pipe(split());
 


### PR DESCRIPTION
Fixes https://github.com/geohacker/geojson-stream-merge/issues/9

Currently if the O/P file already exists, `geojson-stream-merge` appends to it, instead of deleting the file and writing into a fresh file. Fix this.

@geohacker let me know what you think, will wait for a review! : )

cc/ @amishas157 
